### PR TITLE
Added minutes for general assembly 2025

### DIFF
--- a/frontend/src/pages/gf/index.md
+++ b/frontend/src/pages/gf/index.md
@@ -3,6 +3,10 @@ layout: src/layouts/Markdown.astro
 title: Generalforsamling 2025
 ---
 
+**Generalforsamlingen for 2025 er ferdig!**
+
+Her finner du [referatet](/gf/referat)!
+
 ## Hva skjer på generalforsamlingen?
 Generalforsamlingen er linjeforeningens øverste beslutningsorgan og arrangeres for medlemmer hvert vårsemester. Her bestemmes hvem som skal sitte i styret, aktuelle saker for studentene våres, retningen for linjeforeningen det kommende året, og alle medlemmer har mulighet til å påvirke. I tillegg blir det **pizza og brus på alle deltakere**, så her er det ingen grunn til å lure seg unna!
 

--- a/frontend/src/pages/gf/referat.md
+++ b/frontend/src/pages/gf/referat.md
@@ -1,0 +1,93 @@
+---
+layout: src/layouts/Markdown.astro
+title: GF 2025 Referat
+---
+
+**Dato**: 13.02.2025 <br />
+**Tidspunkt**: 16:30 <br />
+**Rom**: C2 042 <br />
+**Deltakere**: 64
+
+- Åpning av møtet
+  - Jakob åpner møte 16:41
+- Protokoll
+  - Inkalling godkjent uten innvendinger
+  - Saksliste godkjent uten innvendinger
+  - Nestleder godkjent som ordstyrer uten innvendinger
+  - Bedkom-leder godkjent som referent uten innvendinger
+  - Oscar Gran Fehn og Aristidis Akritidis valgt til å signere referat
+- Årsberetning
+  - BETA har arrangert 17 ulike eventer
+    - 3 med andre foreninger
+    - 11 bedpresser
+    - 2 LAN
+  - BETA har hatt ukentlige møter for
+    - Hovedstyre
+    - BetaDev
+    - BetaLAN
+    - Eventkom annenhver uke
+  - BetaSec har ikke vert aktiv
+  - Jobbet for å fremme datalab
+- Økonomi
+    - Regnskap
+      - Inntekter 375 973,43kr
+      - Utgifter 398 419,41kr
+      - Mye penger inn etter corona, men mindre aktivitet nå. Fremdeles over 120 000 inn bare i bedriftspresentasjoner og annonser.
+- Vedtektsendringer ([fjorårets vedtekter](/Vedtekter.pdf))
+    - **Interessegrupper/BetaLAN sitt ledervalg**: Til nå har BetaDev/Sec valgt leder internt, og det foreslås å velge disse også på generalforsamlingen som andre komiteer. Da slipper man at interessegruppene blir borte ved lite aktivitet, sitter ikke fast i vennegjeng som uteksamineres og interessegruppen mister alle medlemmer, og gir stemmeinflytelse fra alle Beta medlemmer.
+      - Vedtatt med 53 for, 1 mot, 1 blank
+    - **Leder kan utvelges for innaktive interessegrupper**: Om en interessegruppe blir innaktiv og leder ikke har mulighet til å oppfylle vervet vil styret kunne gjennvelge en ny leder for interessegruppen.
+      - Ikke tatt opp.
+    - **Kåring av æresmedlem**: For å vise at Beta er takknemmelige for at personer utenfor linjeforeningen engasjerer seg, kan man gi ut en pris en gang i året for ikke-medlemmer som har betydd noe for Beta.
+      - Ble presentert som sak, ikke vedtektsendring.
+      - Styret stiller med to kandidater:
+        - Arne Wiklund: 30 stemmer
+        - Bendik Egenes Dyrli: 16 stemmer
+      - Øvrige kandidater presentert under GF:
+        - Halvard Øysæd: 0 stemmer
+    - **PR komite**: For å engasjere flere til å både delta og arrangere seg i linjeforeninga kan PR-rollen bli utvidet til en komite hvor flere kan hjelpe med å fremme linjeforeningen.
+      - To alternativer:
+        - Beholder nåværende løsning med 1 PR ansvarlig: 30 stemmer for
+        - Endre til en av to alternative løsninger: 17 stemmer for
+        - 7 blanke stemmer
+        - Ingen endring vedtatt.
+    - **Generalforsamling på høsten**: For å kapre flere engasjerte studenter, må det skje tidligere før andre foreninger tar de.
+      - Ikke vedtatt med alle mot utenom 1 blank.
+    - **Egen AI-interessegruppe**: En egen interessegruppe for å jobbe med AI-relaterte prosjekter.
+      - Ikke vedtatt med 20 for, 15 imot, 17 blank (må være 2/3 for)
+      - Rette skrivefeil vedtatt: 36 for, 9 imot, 1 blank
+- Innkomne saker ([send inn forslag](https://forms.office.com/e/7f26pjvktU))
+    - **Prisjustering for bedpresser**: Bedkom skrur opp prisen for bedpress, med bakgrunn på at dette ikke er gjort på lenge.
+      - Per dags dato tar vi 12 000kr + moms for en bedpress
+      - Ide om å ta kontakt med næringsrepresentant i kommunen (for å øke bedriftssamarbeid)
+      - Ide om å senke prisen er tatt opp
+      - Ide om å variere prisen for ulike bedrifter basert på størrelse
+    - **Promotering/definere BetaDev prosjekter**: Lage tydelige oppgaver og beskrivelser av prosjekter for å lett kunne delta og jobbe på møtene.
+      - Ask presenterer saken
+        - BetaDev ble reklamert for
+    - **Kode-kvelder**: Ha flere kvelder hvor man kan hygge seg og kode alle mulige saker, både studierelevant og egne prosjekter, hvor man kan sammarbeide, dele og få hjelp.
+      - God interesse for å holde både kode-kvelder og pils og programmering
+        - Tuesday code lounge på studentloungen
+      - Eventkomiteen tar det videre
+    - **Kodekonkurranser**: BetaDev kunne både arrangert og deltat i kodekonkurranser.
+      - Hackathons
+      - CTF-er under BetaSec
+      - Konkurranser der man skal skrive så effektiv kode som mulig
+        - Problemet med bruk av chatgpt tatt opp
+      - BetaDev tar det videre
+    - **(Extra) Beta medlemmer diskuterer sammen og deler med forsamlingen**
+- Intro til styreverv
+  - De ulike lederene presenterer sine verv
+- Valg av styre ([verv som kan stilles til](/om/verv))
+  - Leder: Jakob Moen Bekken valgt uten motkandidat
+  - Nestleder: Oscar Gran Fehn valgt uten motkandidat
+  - Økonomiansvarlig: Benjamin Nylund vant mot Andreas Røberg Beitnes
+  - PR leder: Lars Angel Høydahl Ohme
+  - BetaLAN leder: Albert Salvesen-Orø
+  - Eventkom leder: Vetle Andreas Tysland
+  - BedKom leder: Andreas Røberg Beitnes
+  - BetaDev leder: Morten Andreas Myrstad
+  - BetaSec leder: Magnus Johannesen vant mot Chriss Olav Furenes
+- Pizza og drikke!
+- Avsluttning
+  - Generalforsamling hevet 19:08


### PR DESCRIPTION
Added link to and the minutes from GF 2025 itself to `/gf/referat`. 