### PR TITLE
fix/about us light mode

### DIFF
--- a/frontend/src/pages/om/index.astro
+++ b/frontend/src/pages/om/index.astro
@@ -76,7 +76,7 @@ import EventkomImage from "@assets/groups/eventkom.jpg";
   </Container>
 
   <Container>
-    <h2 class="mb-4 border-b-2 border-gray-300 pb-2 text-3xl font-semibold text-white">
+    <h2 class="mb-4 border-b-2 border-gray-600 pb-2 text-3xl font-semibold dark:border-gray-400">
       Interessegrupper
     </h2>
     <div class="my-4 grid grid-cols-1 gap-4 md:grid-cols-2 md:px-0">
@@ -92,7 +92,9 @@ import EventkomImage from "@assets/groups/eventkom.jpg";
         alt="Betadev"
       />
     </div>
-    <h2 class="mb-4 mt-12 border-b-2 border-gray-300 pb-2 text-3xl font-semibold text-white">
+    <h2
+      class="mb-4 mt-12 border-b-2 border-gray-600 pb-2 text-3xl font-semibold dark:border-gray-400"
+    >
       Komitéer
     </h2>
     <div class="my-4 grid grid-cols-1 gap-4 md:grid-cols-3 md:px-0">


### PR DESCRIPTION
About us got invisible text on two headers and borders in light mode. This fix gives color in dark and light that is possible to read!