### PR TITLE
Fix/exam content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/components/ui/SortList.astro
+++ b/frontend/src/components/ui/SortList.astro
@@ -1,19 +1,9 @@
 ---
 import { Icon } from "astro-icon/components";
-interface Pdf {
-  name: string | undefined;
-  href: string | undefined;
-  year: string | undefined;
-  examNumber: string | undefined;
-  score: string | undefined;
-  nickname: string | undefined;
-}
+import type { SortListProps } from "@lib/types/props";
+import type { Pdf } from "@lib/types/models";
 
-export interface Props {
-  files: Pdf[];
-}
-
-const { files } = Astro.props as Props;
+const { files } = Astro.props as SortListProps;
 ---
 
 <div class="overflow-auto rounded border-2 border-brand text-black dark:text-white">

--- a/frontend/src/content/config.ts
+++ b/frontend/src/content/config.ts
@@ -1,0 +1,17 @@
+import { defineCollection, z } from "astro:content";
+
+const exams = defineCollection({
+  type: "data",
+  schema: z.object({
+    name: z.string(),
+    href: z.string().url(),
+    year: z.string(),
+    examNumber: z.string(),
+    score: z.string(),
+    nickname: z.string(),
+  }),
+});
+
+export const collections = {
+  exams,
+};

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -1,0 +1,8 @@
+export interface Pdf {
+  name: string | undefined;
+  href: string | undefined;
+  year: string | undefined;
+  examNumber: string | undefined;
+  score: string | undefined;
+  nickname: string | undefined;
+}

--- a/frontend/src/lib/types/props.ts
+++ b/frontend/src/lib/types/props.ts
@@ -1,0 +1,5 @@
+import type { Pdf } from "@lib/types/models";
+
+export interface SortListProps {
+  files: Pdf[];
+}

--- a/frontend/src/pages/exams/[subject].astro
+++ b/frontend/src/pages/exams/[subject].astro
@@ -3,20 +3,21 @@ import type { GetStaticPaths } from "astro";
 import Container from "@components/containers/Container.astro";
 import PageLayout from "@layouts/PageLayout.astro";
 import SortList from "@components/ui/SortList.astro";
+import type { Pdf } from "@lib/types/models";
 
-import fs from "fs";
 import path from "path";
 
-export const getStaticPaths = (() => {
-  const subjectsDir = path.resolve("src/content/exams");
-  const folders = fs
-    .readdirSync(subjectsDir)
-    .filter(name => fs.statSync(path.join(subjectsDir, name)).isDirectory());
+export const getStaticPaths: GetStaticPaths = () => {
+  const subjectFolders = import.meta.glob("@content/exams/*/*.pdf", { eager: true });
+
+  const folders = [
+    ...new Set(Object.keys(subjectFolders).map(file => path.basename(path.dirname(file)))),
+  ];
 
   return folders.map(subject => ({
     params: { subject },
   }));
-}) satisfies GetStaticPaths;
+};
 
 const { subject } = Astro.params;
 
@@ -24,27 +25,24 @@ const pdfImports = import.meta.glob<{ default: string }>("@content/exams/*/*.pdf
   eager: true,
 });
 
-const pdfFiles = Object.entries(pdfImports)
-  .filter(([path]) => path.includes(`/${subject}/`))
-  .map(([path, mod]) => {
-    const fileName: string | undefined = path.split("/").pop();
-    // Ensure that pdf file names follow -> year-semester-score-subject.pdf format
-    // year -> yyyy
-    // examNumber -> 1...?
-    // score -> 0...100
-    //nickname -> nickname_with_underscores_for_spaces
-    const [year, examNumber, score, nickname, ...rest] =
-      fileName?.replace(".pdf", "").split("-") || [];
+const pdfFiles: Pdf[] = Object.entries(pdfImports)
+  .filter(([filePath]) => filePath.includes(`/${subject}/`))
+  .map(([filePath, mod]) => {
+    const fileName = path.basename(filePath);
+    if (!fileName.includes("-")) return null;
+
+    const [year, examNumber, score, nickname] = fileName.replace(".pdf", "").split("-");
 
     return {
       name: fileName,
       href: mod.default,
-      year: year,
-      examNumber: examNumber,
-      score: score,
-      nickname: nickname,
+      year,
+      examNumber,
+      score,
+      nickname,
     };
-  });
+  })
+  .filter(Boolean) as Pdf[];
 ---
 
 <PageLayout title="Exams">

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,7 +7,8 @@
       "@assets/*": ["src/assets/*"],
       "@layouts/*": ["src/layouts/*"],
       "@pages/*": ["src/pages/*"],
-      "@content/*": ["src/content/*"]
+      "@content/*": ["src/content/*"],
+      "@lib/*": ["src/lib/*"]
     }
   }
 }


### PR DESCRIPTION
Redid the content loading with `import.meta.glob` instead of `fs` for it to work in both prod and dev. Also typed the PDFs right and added a content config file to fix deprecated warning. This will now load the content right to the site!

Fixes #107 