### PR TITLE
🩹 Moved banner into reusable component (#133)

### DIFF
--- a/frontend/src/components/widgets/Banner.astro
+++ b/frontend/src/components/widgets/Banner.astro
@@ -1,0 +1,37 @@
+---
+import type { BannerProps } from "@lib/types/props";
+
+const { text, link, buttonText = "Les mer!" } = Astro.props;
+---
+
+<div
+  id="banner"
+  class="fixed bottom-6 left-1/2 z-50 w-[90%] max-w-xl -translate-x-1/2 transform rounded-xl bg-brand px-6 py-4 text-white shadow-lg transition-all duration-500"
+>
+  <div class="flex items-center justify-between">
+    <p class="flex items-center text-sm font-semibold sm:text-base">
+      {text}
+    </p>
+    <a
+      href={link}
+      class="rounded-lg bg-white px-4 py-2 text-sm font-bold text-brand shadow transition hover:bg-gray-100"
+    >
+      {buttonText}
+    </a>
+  </div>
+</div>
+
+<script>
+  const banner = document.getElementById("banner");
+  let lastScrollY = 0;
+
+  window.addEventListener("scroll", () => {
+    if (!banner) return;
+    if (window.scrollY > lastScrollY) {
+      banner.style.transform = "translate(-50%, 150%)";
+    } else {
+      banner.style.transform = "translate(-50%, 0)";
+    }
+    lastScrollY = window.scrollY;
+  });
+</script>

--- a/frontend/src/lib/types/props.ts
+++ b/frontend/src/lib/types/props.ts
@@ -1,5 +1,10 @@
 import type { Pdf } from "@lib/types/models";
 
+export interface BannerProps {
+  text: string;
+  link: string;
+  buttonText?: string;
+}
 export interface SortListProps {
   files: Pdf[];
 }

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -3,7 +3,12 @@ import PageLayout from "@layouts/PageLayout.astro";
 import FullContainer from "@components/containers/FullContainer.astro";
 import Button from "@components/ui/Button.astro";
 import BetaLogo from "@assets/logos/Beta.svg";
-import { Icon } from "astro-icon/components";
+
+import Banner from "@components/widgets/Banner.astro";
+
+const showBanner = false;
+const bannerText = "";
+const bannerLink = "/";
 ---
 
 <PageLayout title="Home">
@@ -24,37 +29,7 @@ import { Icon } from "astro-icon/components";
         </div>
       </div>
     </div>
-    <!-- Banner nederst -->
-    <div
-      id="banner"
-      class="fixed bottom-6 left-1/2 z-50 w-[90%] max-w-xl -translate-x-1/2 transform rounded-xl bg-brand px-6 py-4 text-white shadow-lg transition-all duration-500"
-    >
-      <div class="flex items-center justify-between">
-        <p class="flex items-center gap-2 text-sm font-semibold sm:text-base">
-          🚀 Bli med på vår Git Workshop! <Icon name="fa-solid:code-branch" class="" />
-        </p>
-        <a
-          href="/workshop/git"
-          class="rounded-lg bg-white px-4 py-2 text-sm font-bold text-brand shadow transition hover:bg-gray-100"
-        >
-          Les mer
-        </a>
-      </div>
-    </div>
 
-    <script>
-      const banner = document.getElementById("banner");
-      let lastScrollY = 0;
-
-      window.addEventListener("scroll", () => {
-        if (!banner) return;
-        if (window.scrollY > lastScrollY) {
-          banner.style.transform = "translate(-50%, 150%)";
-        } else {
-          banner.style.transform = "translate(-50%, 0)";
-        }
-        lastScrollY = window.scrollY;
-      });
-    </script>
+    {showBanner && <Banner text={bannerText} link={bannerLink} />}
   </FullContainer>
 </PageLayout>


### PR DESCRIPTION
Moved the Git banner into a reusable banner component that is turned off by default, and can be used on several pages with different info.